### PR TITLE
modified avg calc method

### DIFF
--- a/script.js
+++ b/script.js
@@ -1330,19 +1330,24 @@ function Workers_detail(xid){
 		api('workerdetail', xid, d.name).then(function(){
 			var avg = 0,
 				havg = 0,
+				auc = 0,
 				maxtime = 99999999999999999,
 				timestart = maxtime,
 				cnt = numObj($A[addr].wrkrs[xid].stats),
 				i = cnt;
 
 			var hshx = document.getElementById('HashSelect').value == 'raw' ? "hsh" : "hsh2";
-			while(i--){
-				avg = avg + parseInt($A[addr].wrkrs[xid].stats[i][hshx]);
+			//while(i--){
+			while(i > 1) {
+				i--;
+				auc += ($A[addr].wrkrs[xid].stats[i - 1][hshx] + $A[addr].wrkrs[xid].stats[i][hshx]) * ($A[addr].wrkrs[xid].stats[i - 1].tme - $A[addr].wrkrs[xid].stats[i].tme) / 2;
+				//avg = avg + parseInt($A[addr].wrkrs[xid].stats[i][hshx]);
 				SynchTime($A[addr].wrkrs[xid].stats[i].tme);
 				if($A[addr].wrkrs[xid].stats[i].tme < timestart) timestart = $A[addr].wrkrs[xid].stats[i].tme;
 			}
 			p.innerHTML = '<div id="WorkerPopClose" class="C1fl Btn16 Btn16Corner">'+$I.x+'</div>'+
-				'<div class="BoxL center">' + HashConvStr(Rnd(avg / cnt, 0)) + '</div>'+
+				//'<div class="BoxL center">' + HashConvStr(Rnd(avg / cnt, 0)) + '</div>'+
+				'<div class="BoxL center">' + HashConvStr(Rnd(auc / ($A[addr].wrkrs[xid].stats[0].tme - $A[addr].wrkrs[xid].stats[cnt - 1].tme), 0)) + '</div>'+
 				'<div class="BoxR center">'+AgoTooltip(d.last, 'y')+'</div>'+
 				'<div class="pbar shim4"></div>'+
 				'<div class="BoxL txttny C2 center">Avg '+(timestart == maxtime ? "n/a" : AgoTooltip(timestart))+'</div>'+
@@ -2120,6 +2125,7 @@ function Graph_Miner(){
 		cnt = numObj($H),
 		points = [],
 		pts = '',
+		auc = 0,  // area under curve
 		avg = 0,
 		max = 0,
 		yL = 0,
@@ -2129,16 +2135,19 @@ function Graph_Miner(){
 	var hshx = document.getElementById('HashSelect').value == 'raw' ? "hsh" : "hsh2";
 
 	i = cnt;
-	while(i--){
-		avg = avg + $H[i][hshx];
+	//while(i--){
+	while(i > 1) {
+		i--;
+		auc += ($H[i - 1][hshx] + $H[i][hshx]) * ($H[i - 1].tme - $H[i].tme) / 2;
+		// avg = avg + $H[i][hshx];
 		if($H[i][hshx] > max) max = $H[i][hshx];
 		if($H[i].tme < timefirst) timefirst = $H[i].tme;
 	}
 	if(max > 0){
 		if(timefirst >= timestart) timestart = timefirst;
 		max = max * 1.2;
-		avg = avg / cnt;
-		
+		// avg = avg / cnt;
+		avg = auc / ($H[0].tme - $H[cnt - 1].tme);
 		//Create Points
 		for(i = 0; i < cnt; i++){
 			var x = Rnd(right_x - (now - $H[i].tme) * (right_x / (now - timestart)), 1),


### PR DESCRIPTION
Current average hashrate calculating method is based on hashrate sampling in a period of time, which would add up hashrates of each sample point, and calculates average by number of points, which is very likely to cause misestimation due to uneven sampling intervals. 

What's more, the backend records mining machine online/offline events as sample points of history hashrate data. Here is an example,
```javascript
[
    {tme: 1615118007, hsh: 1305.68182347955076, hsh2: 18976.008389475344}, 
//   >>>> only 1 sec. <<<<<<
    {tme: 1615118006, hsh: 0, hsh2: 0}, 
    {tme: 1615115424, hsh: 0, hsh2: 0}, 
//   >>>> only 1 sec. <<<<<<
    {tme: 1615115423, hsh: 1290.3090955446069, hsh2: 17659.437242126016} 
]
```
While intervals between zero and non-zero values are extremely narrow, calculation will evaluate them as equal, which causes further inaccuracy.

Here the modified method calculates average by "area under curve", which is less affected by either vertical (hashrate) or horizontal (time interval) fluctuation. 